### PR TITLE
Make the .refcache directory configurable

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -407,7 +407,7 @@ module Kramdown
         end
       end
 
-      REFCACHEDIR = ".refcache"
+      REFCACHEDIR = ENV["KRAMDOWN_REFCACHEDIR"] || ".refcache"
       def get_and_cache_resource(url, tn = Time.now, tvalid = 7200)
         Dir.mkdir(REFCACHEDIR) unless Dir.exists?(REFCACHEDIR)
         fn = "#{REFCACHEDIR}/#{File.basename(url)}"


### PR DESCRIPTION
xml2rfc has a global cache.  Conveniently, it uses the same technique for
caching as kramdown-rfc2629.  This allows users to point to the same
location, so that there can be cache reuse.