### PR TITLE
Check if the openssl file (or files) exist

### DIFF
--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -10,11 +10,11 @@ require 'date'
 Encoding.default_external = "UTF-8" # wake up, smell the coffee
 
 def do_the_tls_dance
-  begin
-    require 'openssl'
-    File.open(OpenSSL::X509::DEFAULT_CERT_FILE) do end
-  rescue
-    warn "** Configuration problem with OpenSSL certificate store at #{OpenSSL::X509::DEFAULT_CERT_FILE}."
+  require 'openssl'
+  if !File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE) &&
+     (!Dir.exist?(OpenSSL::X509::DEFAULT_CERT_DIR) ||
+      Dir[File.join(OpenSSL::X509::DEFAULT_CERT_DIR, "*.pem")].none?)
+    warn "** Configuration problem with OpenSSL certificate store."
     warn "**   Activating workaround.  Occasionally run `certified-update`."
     require 'certified'
   end


### PR DESCRIPTION
Rather than try to open the certificate file, check if it exists.  For the directory, go one step further and check if there are `.pem` files there.  (Caveat: I have verified that this works on both Fedora and Ubuntu, but that's all.)  There is only so far we can reasonably go here.

Closes #48 
