### PR TITLE
added --version and --help and show version

### DIFF
--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -7,6 +7,9 @@ require 'yaml'
 require 'erb'
 require 'date'
 
+# not sure how to get this from gemspec.
+VERSION="1.3.8-mcr"
+
 Encoding.default_external = "UTF-8" # wake up, smell the coffee
 
 def boilerplate(key)
@@ -287,8 +290,16 @@ require 'ostruct'
 
 $options = OpenStruct.new
 op = OptionParser.new do |opts|
-  opts.banner = "Usage: kramdown-rfc2629 [options] file.md|file.mkd > file.xml"
+  opts.banner = "Usage: kramdown-rfc2629 [options] file.md|file.mkd > file.xml (#{VERSION})"
 
+  opts.on("-V", "--version", "Show version and exit") do |v|
+    puts "kramdown-rfc2629 #{VERSION}"
+    exit
+  end
+  opts.on("-h", "--help", "Show option summary and exit") do |v|
+    puts opts
+    exit
+  end
   opts.on("-v", "--[no-]verbose", "Run verbosely") do |v|
     $options.verbose = v
   end

--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -7,8 +7,8 @@ require 'yaml'
 require 'erb'
 require 'date'
 
-# not sure how to get this from gemspec.
-VERSION="1.3.8-mcr"
+# try to get this from gemspec.
+VERSION=Gem.loaded_specs["kramdown-rfc2629"].version rescue "unknown-version"
 
 Encoding.default_external = "UTF-8" # wake up, smell the coffee
 


### PR DESCRIPTION
I don't know how/if one can pull the version out of the gemspec.  Or maybe it can be done the other way.
And if it running from git checkout it should say that.
But for now, it requires the version to be updated in two places.
