### PR TITLE
Fix warning for anchor redefinition

### DIFF
--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -154,7 +154,7 @@ def xml_from_sections(input)
       if bibref
         if old = anchor_to_bibref[word]
           if bibref != old
-            warn "*** conflicting definitions for xref #{anchor}: #{old} != #{bibref}"
+            warn "*** conflicting definitions for xref #{word}: #{old} != #{bibref}"
           end
         else
           anchor_to_bibref[word] = bibref


### PR DESCRIPTION
`anchor` is undefined at this point, so if you map the same name to two different targets it crashes instead of reporting a useful error.