### PR TITLE
Depend on json_pure

### DIFF
--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -6,7 +6,7 @@ spec = Gem::Specification.new do |s|
 "kramdown" markdown parser.  Mostly useful for RFC writers.}
   s.add_dependency('kramdown', '~> 1.17.0')
   s.add_dependency('certified', '~> 1.0')
-  s.add_dependency('json', '~> 2.0')
+  s.add_dependency('json_pure', '~> 2.0')
   s.files = Dir['lib/**/*.rb'] + %w(README.md LICENSE kramdown-rfc2629.gemspec bin/kdrfc bin/kramdown-rfc2629 bin/doilit bin/kramdown-rfc-extract-markdown data/kramdown-rfc2629.erb data/encoding-fallbacks.txt data/math.json)
   s.require_path = 'lib'
   s.executables = ['kramdown-rfc2629', 'doilit', 'kramdown-rfc-extract-markdown', 'kdrfc']


### PR DESCRIPTION
If json is present (which it will be in many cases), then this has no
real effect as `require 'json'` will only use json_pure if there is no
json module.

However, this makes the gem easier to install as installing the json gem
requires a C compiler.

Closes #94.