### PR TITLE
Remove target attributes on RFC and I-D references

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -839,8 +839,11 @@ COLORS
             # end
             to_insert = get_and_cache_resource(url, fn.gsub('/', '_'), ttl)
             to_insert.scrub! rescue nil # only do this for Ruby >= 2.1
-            to_insert.gsub!(%r{target="https?://www.ietf.org/internet-drafts/},
-                            %{target="https://www.ietf.org/archive/id/}) if t == "I-D"
+            if t == "RFC" or t == "I-D"
+              # Let xml2rfc --id-base-url and --rfc-base-url work.
+              to_insert.sub!(%r{(<reference\s+.*)\s+target=(?:'[^']*'|"[^"]*")}, '\1')
+              to_insert.gsub!(%r{\s+<format[^>]*/>}, "")
+            end
             # this may be a bit controversial: Don't break the build if reference is broken
             if KRAMDOWN_OFFLINE
               unless to_insert


### PR DESCRIPTION
xml2rfc provides a means to configure the target URL for RFCs and
Internet-Drafts if there is no pre-existing target with `--rfc-base-url`
and `--id-base-url`.  Rather than have kramdown-rfc2629 express an
opinion about this, let that opinion be expressed through those flags
instead.

I don't know how you would prefer to configure this, so I'm just
offering this without configuration for now.  Happy to adjust
accordingly.