### PR TITLE
<xref format="counter"/>

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -106,7 +106,10 @@ module Kramdown
               href = $2
               attr['section'] = $1
               attr['sectionFormat'] = 'bare'
-            when /\A([\w.]+)<\z/
+            when /\A<<(.+)\z/
+              href= $1
+              attr['format'] = 'title'
+            when /\A<(.+)\z/
               href= $1
               attr['format'] = 'counter'
             end

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -102,11 +102,11 @@ module Kramdown
             when /\A(.*) \((#{SECTIONS_RE})\)\z/
               href = $1
               handle_bares($2, attr, "parens", href)
-            when /\A(.+)<(.+)\z/
+            when /\A([\w.]+)<(.+)\z/
               href = $2
               attr['section'] = $1
               attr['sectionFormat'] = 'bare'
-            when /\A(.+)<\z/
+            when /\A([\w.]+)<\z/
               href= $1
               attr['format'] = 'counter'
             end

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -102,10 +102,13 @@ module Kramdown
             when /\A(.*) \((#{SECTIONS_RE})\)\z/
               href = $1
               handle_bares($2, attr, "parens", href)
-            when /\A([\w.]+)<(.*)\z/
+            when /\A(.+)<(.+)\z/
               href = $2
               attr['section'] = $1
               attr['sectionFormat'] = 'bare'
+            when /\A(.+)<\z/
+              href= $1
+              attr['format'] = 'counter'
             end
           end
           href = href.gsub(/\A[0-9]/) { "_#{$&}" } # can't start an IDREF with a number
@@ -907,7 +910,7 @@ COLORS
                   }
                 else
                   REXML::XPath.each(d.root, "/reference/format") { |x|
-                    x.attributes["target"].sub!(%r{https?://www.ietf.org/internet-drafts/}, 
+                    x.attributes["target"].sub!(%r{https?://www.ietf.org/internet-drafts/},
                                                 %{https://www.ietf.org/archive/id/}) if t == "I-D"
                   }
                 end


### PR DESCRIPTION
This takes the bare section reference format of `{{1.3<RFC2119}}` and
makes it available for local use by dropping the external reference and
replacing the section number with a local section reference.

That is, where `{{foo}}` would produce `<xref target="foo"
format="default"/>`, `{{foo<}}` produces `<xref target="foo"
format="counter"/>`.

The previous code would generate the invalid `<xref target=""
section="foo" sectionFormat="bare"/>` for this case, so I believe that
this is safe.