### PR TITLE
Match Appendix and Appendices for section reference format

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -42,14 +42,15 @@ module Kramdown
         @block_parsers.unshift(:block_pi)
       end
 
-      SECTIONS_RE = /Section(?:s (?:[\w.]+, )*[\w.]+,? and)? [\w.]+/
+      SECTIONS_RE = /(?:Sections?|Appendi(?:x|ces))(?: (?:[\w.]+, )*[\w.]+,? and)? [\w.]+/
 
       def handle_bares(s, attr, format, href)
-        sa = s.sub(/\A\S+\s/, '').split(/,? and /)
+        (sect, secn) = s.split(/\s/, 2)
+        sa = secn.split(/,? and /)
         sa[0..0] = *sa[0].split(', ')
         sz = sa.size
         if sz != 1         # we have to redo xml2rfc's work here
-          @tree.children << Element.new(:text, "Sections ", {}) # XXX needs to split into Section/Appendix
+          @tree.children << Element.new(:text, "#{sect} ", {}) # XXX needs to split into Section/Appendix
           sa.each_with_index do |sec, i|
             attr1 = {"target" => href, "section" => sec, "sectionFormat" => "bare"}
             @tree.children << Element.new(:xref, nil, attr1)

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -50,7 +50,7 @@ module Kramdown
         sa[0..0] = *sa[0].split(', ')
         sz = sa.size
         if sz != 1         # we have to redo xml2rfc's work here
-          @tree.children << Element.new(:text, "#{sect} ", {}) # XXX needs to split into Section/Appendix
+          @tree.children << Element.new(:text, "#{sect} ", {})
           sa.each_with_index do |sec, i|
             attr1 = {"target" => href, "section" => sec, "sectionFormat" => "bare"}
             @tree.children << Element.new(:xref, nil, attr1)
@@ -908,7 +908,7 @@ COLORS
                   }
                 else
                   REXML::XPath.each(d.root, "/reference/format") { |x|
-                    x.attributes["target"].sub!(%r{https?://www.ietf.org/internet-drafts/}, 
+                    x.attributes["target"].sub!(%r{https?://www.ietf.org/internet-drafts/},
                                                 %{https://www.ietf.org/archive/id/}) if t == "I-D"
                   }
                 end


### PR DESCRIPTION
This isn't *exactly* what was there before.  It now matches against "Section 2 and 3 of FOO" whereas previously you needed to include the plural for that case; and it matches "Appendices A of FOO".  But making that work without also matching "SectionAppendices 2 and 3 of FOO" was more work than I thought worth investing.

There is maybe `(?:Section|Appendi(?:x|ce))(?:s ...` but that would match "Appendice 1 of FOO" and "Appendixs 2 and 3 of FOO".

Correct subject-object agreement is something that can be sorted at a higher layer, perhaps.