### PR TITLE
<xref> text in parentheses

### DIFF
--- a/bin/kramdown-rfc-cache-subseries-bibxml
+++ b/bin/kramdown-rfc-cache-subseries-bibxml
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# prerequisite:
+# gem install net-http-persistent
+#
+# generates referencegroup files for BCP and STD series (like bibxml9)
+# unfortunately, needs to re-fetch rfc-index.xml
+# uses pretty slow built-in XML parser, so it will take a while even on regen
+#
+# uses ENV["KRAMDOWN_REFCACHEDIR"] for where you want to have your bibxml9 data
+#
+
+require 'rexml/document'
+require 'fileutils'
+
+begin
+  require 'net/http/persistent'
+rescue
+  warn "*** please install net-http-persistent:"
+  warn "   gem install net-http-persistent"
+  warn "(prefix by sudo only if required)."
+  exit 72                       # EX_OSFILE
+end
+
+
+TARGET_DIR = ENV["KRAMDOWN_REFCACHEDIR"] || (
+  path = File.expand_path("~/.cache/xml2rfc")
+  warn "*** set environment variable KRAMDOWN_REFCACHEDIR to #{path} to actually use the cache"
+  path
+)
+
+FileUtils.mkdir_p(TARGET_DIR)
+FileUtils.chdir(TARGET_DIR)
+
+$http = Net::HTTP::Persistent.new name: 'subseries'
+
+KRAMDOWN_PERSISTENT_VERBOSE = true
+
+      def get_and_write_resource_persistently(url, fn, age_verbose=false)
+        t1 = Time.now
+        response = $http.request(URI(url))
+        if response.code != "200"
+          raise "*** Status code #{response.code} while fetching #{url}"
+        else
+          File.write(fn, response.body)
+        end
+        t2 = Time.now
+        warn "#{url} -> #{fn} (#{"%.3f" % (t2 - t1)} s)" if KRAMDOWN_PERSISTENT_VERBOSE
+        if age_verbose
+          if age = response.get_fields("age")
+            warn "(working from a web cache, index is #{age.first} seconds stale)"
+          end
+        end
+      end
+
+CLEAR_RET = "\e[K\r" # XXX all the world is ECMA-48 (ISO 6429), no?
+
+      def noisy(name)
+        print "#{name}...#{CLEAR_RET}"
+      end
+      def clear_noise
+        print CLEAR_RET
+      end
+
+def normalize_name(n)
+  n.sub(/([A-Z])0+/) {$1}
+end
+
+def regress_name(n)
+  n.sub(/([A-Z])(\d+)/) {"#$1#{"%04d" % $2.to_i}"}
+end
+
+def regress_name_dot(n)
+  n.sub(/([A-Z])(\d+)/) {"#$1.#{"%04d" % $2.to_i}"}
+end
+
+def get_ref(rfcname)
+  name = "reference.#{regress_name_dot(rfcname)}.xml"
+  begin
+    file = File.read(name)      # no age check
+  rescue Errno::ENOENT
+    get_and_write_resource_persistently("https://www.rfc-editor.org/refs/bibxml/" << name, name)
+    file = File.read(name)
+  end
+  d = REXML::Document.new(file)
+  d.xml_decl.nowrite
+  "<!-- #{name} -->\n" << d.to_s.lstrip
+end
+
+def create_bib(series, subname, rfcnames)
+  p [series, subname, rfcnames]
+  subname_norm = normalize_name(subname)
+  refs = %{<?xml version='1.0' encoding='UTF-8'?>\n}
+  refs << %{<referencegroup anchor='#{subname_norm}' target='https://www.rfc-editor.org/info/#{subname_norm.downcase}'>\n}
+  refs << rfcnames.map {|x| get_ref(x)}.join
+  refs << "</referencegroup>\n"
+  File.write("reference.#{regress_name_dot(subname)}.xml", refs)
+end
+
+def handle_sub(series, entry)
+  ids = entry.get_elements("doc-id")
+  warn "** ids #{ids} #{entry}" unless ids.size == 1
+  subname = ids.first.text
+  isalso = entry.get_elements("is-also")
+  if isalso.size == 1
+    rfcs = isalso.first.get_elements("doc-id")
+    if rfcs.size > 0
+      rfcnames = rfcs.map {|r| r.text}
+      create_bib(series, subname, rfcnames)
+    end
+  end
+end
+
+RFCINDEX_SOURCE = "https://www.rfc-editor.org/rfc/rfc-index.xml"
+RFCINDEX_COPY = File.basename(RFCINDEX_SOURCE)
+
+get_and_write_resource_persistently(RFCINDEX_SOURCE, RFCINDEX_COPY, true) unless ENV["KRAMDOWN_DONT_REFRESH_RFCINDEX"]
+
+doc = REXML::Document.new(File.read(RFCINDEX_COPY))
+REXML::XPath.each(doc.root, "/rfc-index/bcp-entry") { |e| handle_sub("BCP", e) }
+REXML::XPath.each(doc.root, "/rfc-index/std-entry") { |e| handle_sub("STD", e) }

--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -269,6 +269,10 @@ def bibtagsys(bib, anchor=nil, stand_alone=true)
     rfc4d = "%04d" % $1.to_i
     [bib.upcase,
      "#{XML_RESOURCE_ORG_PREFIX}/bibxml/reference.RFC.#{rfc4d}.xml"]
+  elsif $options.v3 && bib =~ /\A(bcp|std)(\d+)/i
+    n4d = "%04d" % $2.to_i
+    [bib.upcase,
+     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-subseries/reference.#{$1.upcase}.#{n4d}.xml"]
   elsif bib =~ /\A([-A-Z0-9]+)\./ &&
         (xro = Kramdown::Converter::Rfc2629::XML_RESOURCE_ORG_MAP[$1])
     dir, _ttl, rewrite_anchor = xro

--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -272,7 +272,7 @@ def bibtagsys(bib, anchor=nil, stand_alone=true)
   elsif $options.v3 && bib =~ /\A(bcp|std)(\d+)/i
     n4d = "%04d" % $2.to_i
     [bib.upcase,
-     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-subseries/reference.#{$1.upcase}.#{n4d}.xml"]
+     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/reference.#{$1.upcase}.#{n4d}.xml"]
   elsif bib =~ /\A([-A-Z0-9]+)\./ &&
         (xro = Kramdown::Converter::Rfc2629::XML_RESOURCE_ORG_MAP[$1])
     dir, _ttl, rewrite_anchor = xro

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -100,7 +100,7 @@
         <name>Contributors</name>
 <%   else -%>
     <section anchor="contributors" numbered="false" title="Contributors">
-<%     warn "*** Cannot process YAML contributors under V2 rules" if consec -%>
+<%     warn "*** To use YAML contributors, use --v3 (kdrfc -3)" if consec -%>
 <%   end -%>
 <%= sh -%>
 <% if $options.v3 && consec

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc2629'
-  s.version = '1.4.6'
+  s.version = '1.4.7'
   s.summary = "Kramdown extension for generating RFC 7749 XML."
   s.description = %{An RFC7749 (XML2RFC) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}
@@ -10,7 +10,8 @@ spec = Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb'] + %w(README.md LICENSE kramdown-rfc2629.gemspec bin/kdrfc bin/kramdown-rfc2629 bin/doilit bin/kramdown-rfc-extract-markdown data/kramdown-rfc2629.erb data/encoding-fallbacks.txt data/math.json)
   s.require_path = 'lib'
   s.executables = ['kramdown-rfc2629', 'doilit', 'kramdown-rfc-extract-markdown',
-                   'kdrfc', 'kramdown-rfc-cache-i-d-bibxml']
+                   'kdrfc', 'kramdown-rfc-cache-i-d-bibxml',
+                   'kramdown-rfc-cache-subseries-bibxml']
   s.required_ruby_version = '>= 2.3.0'
   # s.requirements = 'wget'
   #  s.has_rdoc = true

--- a/lib/kramdown-rfc/parameterset.rb
+++ b/lib/kramdown-rfc/parameterset.rb
@@ -34,13 +34,12 @@ module KramdownRFC
       val ||= defcontent
       Array(val).map do |val1|
         v = val1.to_s.strip
-        if markdown             # Uuh.  Heavy coupling.
-          doc = Kramdown::Document.new(v, $global_markdown_options)
-          $stderr.puts doc.warnings.to_yaml unless doc.warnings.empty?
-          contents = doc.to_rfc2629[3..-6] # skip <t>...</t>\n
-        else
-          contents = escape_html(v)
-        end
+        contents =
+          if markdown
+            ::Kramdown::Converter::Rfc2629::process_markdown(v)
+          else
+            escape_html(v)
+          end
         %{<#{[an, *Array(attr).map(&:to_s)].join(" ").strip}>#{contents}</#{an}>}
       end.join(" ")
     end

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -865,13 +865,24 @@ COLORS
         end
       end
 
+      def self.bcp_std_ref(t, n)
+        warn "*** #{t} anchors not supported in v2 format" unless $options.v3
+        "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-rfcsubseries/reference.##{t}.#{"%04d" % n.to_i}.xml"
+      end
+
       # [subdirectory name, cache ttl in seconds, does it provide for ?anchor=]
       XML_RESOURCE_ORG_MAP = {
         "RFC" => ["bibxml", 86400*7, false,
-                  ->(fn, n){ "https://www.rfc-editor.org/refs/bibxml/#{fn}"}
+                  ->(fn, n){ "https://www.rfc-editor.org/refs/bibxml/reference.RFC.#{"%04d" % n.to_i}.xml" }
                  ],
         "I-D" => ["bibxml3", false, false,
                   ->(fn, n){ "https://datatracker.ietf.org/doc/bibxml3/draft-#{n.sub(/\Adraft-/, '')}/xml" }
+                 ],
+        "BCP" => ["bibxml-rfcsubseries", 86400*7, false,
+                  ->(fn, n){ Rfc2629::bcp_std_ref("BCP", n) }
+                 ],
+        "STD" => ["bibxml-rfcsubseries", 86400*7, false,
+                  ->(fn, n){ Rfc2629::bcp_std_ref("STD", n) }
                  ],
         "W3C" => "bibxml4",
         "3GPP" => "bibxml5",

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -311,6 +311,12 @@ module Kramdown
         generate_id(value).gsub(/-+/, '-')
       end
 
+      def self.process_markdown(v)             # Uuh.  Heavy coupling.
+        doc = ::Kramdown::Document.new(v, $global_markdown_options)
+        $stderr.puts doc.warnings.to_yaml unless doc.warnings.empty?
+        doc.to_rfc2629[3..-6] # skip <t>...</t>\n
+      end
+
       SVG_COLORS = Hash.new {|h, k| k}
       <<COLORS.each_line {|l| k, v = l.chomp.split; SVG_COLORS[k] = v}
 black	#000000

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -867,7 +867,7 @@ COLORS
 
       def self.bcp_std_ref(t, n)
         warn "*** #{t} anchors not supported in v2 format" unless $options.v3
-        "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-rfcsubseries/reference.##{t}.#{"%04d" % n.to_i}.xml"
+        "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/reference.#{t}.#{"%04d" % n.to_i}.xml"
       end
 
       # [subdirectory name, cache ttl in seconds, does it provide for ?anchor=]

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -867,16 +867,19 @@ COLORS
 
       def self.bcp_std_ref(t, n)
         warn "*** #{t} anchors not supported in v2 format" unless $options.v3
-        "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/reference.#{t}.#{"%04d" % n.to_i}.xml"
+        [name = "reference.#{t}.#{"%04d" % n.to_i}.xml",
+         "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/#{name}"] # FOR NOW
       end
 
       # [subdirectory name, cache ttl in seconds, does it provide for ?anchor=]
       XML_RESOURCE_ORG_MAP = {
         "RFC" => ["bibxml", 86400*7, false,
-                  ->(fn, n){ "https://www.rfc-editor.org/refs/bibxml/reference.RFC.#{"%04d" % n.to_i}.xml" }
+                  ->(fn, n){ [name = "reference.RFC.#{"%04d" % n.to_i}.xml",
+                              "https://www.rfc-editor.org/refs/bibxml/#{name}"] }
                  ],
         "I-D" => ["bibxml3", false, false,
-                  ->(fn, n){ "https://datatracker.ietf.org/doc/bibxml3/draft-#{n.sub(/\Adraft-/, '')}/xml" }
+                  ->(fn, n){ [fn,
+                              "https://datatracker.ietf.org/doc/bibxml3/draft-#{n.sub(/\Adraft-/, '')}/xml"] }
                  ],
         "BCP" => ["bibxml-rfcsubseries", 86400*7, false,
                   ->(fn, n){ Rfc2629::bcp_std_ref("BCP", n) }
@@ -933,7 +936,7 @@ COLORS
             ttl ||= KRAMDOWN_REFCACHETTL  # everything but RFCs might change a lot
             puts "*** Huh: #{fn}" unless sub
             if altproc && !KRAMDOWN_USE_TOOLS_SERVER
-              url = altproc.call(fn, n)
+              fn, url = altproc.call(fn, n)
             else
               url = "#{XML_RESOURCE_ORG_PREFIX}/#{sub}/#{fn}"
             end

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -90,7 +90,9 @@ module Kramdown
         else
           href = @src[3]
           attr = {}
+          xtxt = nil
           if $options.v3
+            (href, xtxt) = href.split('>', 2)
             # match Section ... of ...; set section, sectionFormat
             case href.gsub(/[\u00A0\s]+/, ' ') # may need nbsp and/or newlines
             when /\A(#{SECTIONS_RE}) of (.*)\z/
@@ -116,7 +118,7 @@ module Kramdown
           end
           href = href.gsub(/\A[0-9]/) { "_#{$&}" } # can't start an IDREF with a number
           attr['target'] = href
-          el = Element.new(:xref, nil, attr)
+          el = Element.new(:xref, xtxt, attr)
         end
         @tree.children << el
       end
@@ -738,7 +740,12 @@ COLORS
           else
             gi ||= "xref"
           end
-          "<#{gi}#{el_html_attributes(el)}/>"
+          if el.value
+            tail = ">#{escape_html(el.value, :text)}</#{gi}>"
+          else
+            tail = "/>"
+          end
+          "<#{gi}#{el_html_attributes(el)}#{tail}"
         end
       end
 

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -62,7 +62,7 @@ module Kramdown
         multi = last_join != nil
         (sn, s) = s.split(' ', 2)
         loop do
-          m = s.match(/\A#{XREF_RE_M}(, |,? and )?/)
+          m = s.match(/\A#{XREF_RE_M}(, (?:and )?| and )?/)
           break if not m
 
           if not multi and not m[2] and not m[3]
@@ -108,7 +108,6 @@ module Kramdown
         else
           href = @src[3]
           attr = {}
-          xtxt = nil
           if $options.v3
             # match Section ... of ...; set section, sectionFormat
             case href.gsub(/[\u00A0\s]+/, ' ') # may need nbsp and/or newlines
@@ -769,10 +768,7 @@ COLORS
             gi ||= "xref"
           end
           if text
-            doc = ::Kramdown::Document.new(text, $global_markdown_options)
-            $stderr.puts doc.warnings.to_yaml unless doc.warnings.empty?
-            t = doc.to_rfc2629[3..-6] # skip <t>...</t>\n
-            tail = ">#{t}</#{gi}>"
+            tail = ">#{Rfc2629::process_markdown(text)}</#{gi}>"
           else
             tail = "/>"
           end

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -42,32 +42,48 @@ module Kramdown
         @block_parsers.unshift(:block_pi)
       end
 
-      SECTIONS_RE = /Section(?:s (?:[\w.]+, )*[\w.]+,? and)? [\w.]+/
+      XREF_RE = /[!\?-]?[\w.-]+(?: \([^)]+\))?/
+      XREF_RE_M = /\A([!\?-]?[\w.-]+)(?: \(([^)]+)\))?/ # matching version of XREF
+      XREF_SINGLE = /(?:Section|Appendix) #{XREF_RE}/
+      XREF_MULTI = /(?:Sections|Appendices) (?:#{XREF_RE}, )*#{XREF_RE},? and #{XREF_RE}/
+      XREF_ANY = /(?:#{XREF_SINGLE}|#{XREF_MULTI})/
+      SECTIONS_RE = /(?:#{XREF_ANY} and )?#{XREF_ANY}/
 
-      def handle_bares(s, attr, format, href)
-        sa = s.sub(/\A\S+\s/, '').split(/,? and /)
-        sa[0..0] = *sa[0].split(', ')
-        sz = sa.size
-        if sz != 1         # we have to redo xml2rfc's work here
-          @tree.children << Element.new(:text, "Sections ", {}) # XXX needs to split into Section/Appendix
-          sa.each_with_index do |sec, i|
-            attr1 = {"target" => href, "section" => sec, "sectionFormat" => "bare"}
-            @tree.children << Element.new(:xref, nil, attr1)
-            text = if i == 0 && sz == 2
-                     " and "
-                   elsif i == sz-1
-                     " of "
-                   elsif i == sz-2
-                     ", and "
-                   else
-                     ", "
-                   end
-            @tree.children << Element.new(:text, text, {})
+      def handle_bares(s, attr, format, href, last_join = nil)
+        if s.match(/\A(#{XREF_ANY}) and (#{XREF_ANY})\z/)
+          handle_bares($1, {}, nil, href, " and ")
+          handle_bares($2, {}, nil, href, " of ")
+          return
+        end
+
+        href = href.split(' ')[0] # Remove any trailing (...)
+        multi = last_join != nil
+        (sn, s) = s.split(' ', 2)
+        loop do
+          m = s.match(/#{XREF_RE_M}(, |,? and )?/)
+          break if not m
+
+          if not multi and not m[2] and not m[3]
+            # Modify |attr| if there is a single reference.  This can only be
+            # used if there is only one section reference and the section part
+            # has no title.
+            attr['section'] = m[1]
+            attr['sectionFormat'] = format
+            attr['text'] = m[2]
+            return
           end
-          # attr stays unchanged, no section added
-        else
-          attr['section'] = sa[-1]
-          attr['sectionFormat'] = format
+
+          if sn
+            @tree.children << Element.new(:text, "#{sn} ", {})
+            sn = nil
+          end
+
+          multi = true
+          s = s[m[0].size..]
+
+          attr1 = { 'target' => href, 'section' => m[1], 'sectionFormat' => 'bare', 'text' => m[2] }
+          @tree.children << Element.new(:xref, nil, attr1)
+          @tree.children << Element.new(:text, m[3] || last_join || " of ", {})
         end
       end
 
@@ -92,7 +108,6 @@ module Kramdown
           attr = {}
           xtxt = nil
           if $options.v3
-            (href, xtxt) = href.split('>', 2)
             # match Section ... of ...; set section, sectionFormat
             case href.gsub(/[\u00A0\s]+/, ' ') # may need nbsp and/or newlines
             when /\A(#{SECTIONS_RE}) of (.*)\z/
@@ -116,9 +131,13 @@ module Kramdown
               attr['format'] = 'counter'
             end
           end
+          if href.match(XREF_RE_M)
+            href = $1
+            attr['text'] = $2
+          end
           href = href.gsub(/\A[0-9]/) { "_#{$&}" } # can't start an IDREF with a number
           attr['target'] = href
-          el = Element.new(:xref, xtxt, attr)
+          el = Element.new(:xref, nil, attr)
         end
         @tree.children << el
       end
@@ -731,6 +750,7 @@ COLORS
 
       def convert_xref(el, indent, opts)
         gi = el.attr.delete('gi')
+        text = el.attr.delete('text')
         target = el.attr['target']
         if target[0] == "&"
           "#{target};"
@@ -740,8 +760,8 @@ COLORS
           else
             gi ||= "xref"
           end
-          if el.value
-            tail = ">#{escape_html(el.value, :text)}</#{gi}>"
+          if text
+            tail = ">#{escape_html(text, :text)}</#{gi}>"
           else
             tail = "/>"
           end


### PR DESCRIPTION
This supports transformations like:

* `{{X (T)}}` -> `<xref target="X">T</xref>`
* `{{Section X of Y}}` -> `<xref target="Y" section="X"/>`
* `{{Section X of Y (T)}}` -> `<xref target="Y" section="X">T</xref>`
* `{{Section X (T) of Y}}` -> `Section <xref target="Y" section="X" sectionFormat="bare">T</xref> of <xref target="Y"/>`
* `{{Section X (TX) of Y (TY)}}` -> `Section <xref target="Y" section="X" sectionFormat="bare">TX</xref> of <xref target="Y">TY</xref>`

Plus all of the above with "Appendix" instead of "Section".

* `{{Sections X (TX) and Y (TY) of Z (TZ)}}` -> `Section <xref target="Z" section="X" sectionFormat="bare">TX</xref> and <xref target="Z" section="Y" sectionFormat="bare">TY</xref> of <xref target="Z">TZ</xref>`
* `{{Sections X (TX), Y (TY) and Z (TZ) of A (TA)}}` as above; with the text bits all being optional
* `{{Sections X (TX), Y (TY), and Z (TZ) of R (TR)}}` with or without an Oxford comma
* `{{Sections X (TX), Y (TY), and Z (TZ) and Appendix A (TA) of R (TR)}}`
* `{{Sections X (TX), Y (TY), and Z (TZ) and Appendices A (TA) and B (TB) of R (TR)}}`
* `{{Section X (TX) and Appendices A (TA) and B (TB) of R (TR)}}`

Quirks and limitations:

* This respects the choice of Oxford comma of authors because it was easier that way.

* Authors need to provide the type of section; it won't infer that A.3 is an Appendix and 4.2 is a Section.

* This accepts `{{Section A and Section B of X}}` and renders it that way (with two text nodes that say "Section ").  Same logic as above.  This is because, the keywords are treated as interchangeable, except that the plural form is needed to include multiple section numbers.

* Text content from the parentheses is simple text that is escaped, not full markdown.

* `{{!FOO}}` and `{{?FOO}}` don't work with this stuff, as before.

Closes #116.
Closes #117.

