### PR TITLE
Expand BCP and STD references

### DIFF
--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -269,6 +269,10 @@ def bibtagsys(bib, anchor=nil, stand_alone=true)
     rfc4d = "%04d" % $1.to_i
     [bib.upcase,
      "#{XML_RESOURCE_ORG_PREFIX}/bibxml/reference.RFC.#{rfc4d}.xml"]
+  elsif $options.v3 && bib =~ /\A(bcp|std)(\d+)/i
+    n4d = "%04d" % $2.to_i
+    [bib.upcase,
+     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-subseries/reference.#{$1.upcase}.#{n4d}.xml"]
   elsif bib =~ /\A([-A-Z0-9]+)\./ &&
         (xro = Kramdown::Converter::Rfc2629::XML_RESOURCE_ORG_MAP[$1])
     dir, _ttl, rewrite_anchor = xro

--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -272,7 +272,7 @@ def bibtagsys(bib, anchor=nil, stand_alone=true)
   elsif $options.v3 && bib =~ /\A(bcp|std)(\d+)/i
     n4d = "%04d" % $2.to_i
     [bib.upcase,
-     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-subseries/reference.#{$1.upcase}.#{n4d}.xml"]
+     "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/reference.#{$1.upcase}.#{n4d}.xml"]
   elsif bib =~ /\A([-A-Z0-9]+)\./ &&
         (xro = Kramdown::Converter::Rfc2629::XML_RESOURCE_ORG_MAP[$1])
     dir, _ttl, rewrite_anchor = xro

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -835,7 +835,7 @@ COLORS
 
       def self.bcp_std_ref(t, n)
         warn "*** #{t} anchors not supported in v2 format" unless $options.v3
-        "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-rfcsubseries/reference.##{t}.#{"%04d" % n.to_i}.xml"
+        "#{XML_RESOURCE_ORG_PREFIX}/bibxml-rfcsubseries-new/reference.#{t}.#{"%04d" % n.to_i}.xml"
       end
 
       # [subdirectory name, cache ttl in seconds, does it provide for ?anchor=]

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -833,13 +833,24 @@ COLORS
         end
       end
 
+      def self.bcp_std_ref(t, n)
+        warn "*** #{t} anchors not supported in v2 format" unless $options.v3
+        "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-rfcsubseries/reference.##{t}.#{"%04d" % n.to_i}.xml"
+      end
+
       # [subdirectory name, cache ttl in seconds, does it provide for ?anchor=]
       XML_RESOURCE_ORG_MAP = {
         "RFC" => ["bibxml", 86400*7, false,
-                  ->(fn, n){ "https://www.rfc-editor.org/refs/bibxml/#{fn}"}
+                  ->(fn, n){ "https://www.rfc-editor.org/refs/bibxml/reference.RFC.#{"%04d" % n.to_i}.xml" }
                  ],
         "I-D" => ["bibxml3", false, false,
                   ->(fn, n){ "https://datatracker.ietf.org/doc/bibxml3/draft-#{n.sub(/\Adraft-/, '')}/xml" }
+                 ],
+        "BCP" => ["bibxml-rfcsubseries", 86400*7, false,
+                  ->(fn, n){ Rfc2629::bcp_std_ref("BCP", n) }
+                 ],
+        "STD" => ["bibxml-rfcsubseries", 86400*7, false,
+                  ->(fn, n){ Rfc2629::bcp_std_ref("STD", n) }
                  ],
         "W3C" => "bibxml4",
         "3GPP" => "bibxml5",


### PR DESCRIPTION
The main problem that I see with this change is that it relies on tools.ietf.org.

If rfc-editor.org were to serve these, that would be much better, but
that doesn't currently happen.  I'm not tracking that work closely, so
maybe I've missed the feature request.

I "fixed" the RFC referencing part as well by adding leading zeros
automatically.  That was being done inconsistently throughout.

This only really works in v3 format documents as these references use
\<referencegroup>, so I did my best to disable that.