### PR TITLE
do not repeat BCP14, just use two boilerplates

### DIFF
--- a/bin/kramdown-rfc2629
+++ b/bin/kramdown-rfc2629
@@ -49,6 +49,13 @@ TAGGED
       end
     end
     ret
+  when /\Abcp14info\z/i
+    ret = <<RFC8174ise
+Although this document is not an IETF Standards Track publication it
+adopts the conventions for normative language to provide clarity of
+instructions to the implementer.
+RFC8174ise
+    ret
   else
     warn "** Unknwon boilerplate key: #{key}"
     "{::boilerplate #{key}}"


### PR DESCRIPTION
added bcp14 prefix for when BCP14 language is used outside of standards track