### PR TITLE
Add 'drawing' as an artwork type

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -468,7 +468,7 @@ COLORS
         [result, result1]       # text, svg
       end
 
-      ARTWORK_TYPES = %w(ascii-art binary-art call-flow hex-dump svg)
+      ARTWORK_TYPES = %w(ascii-art binary-art call-flow drawing hex-dump svg)
 
       def convert_codeblock(el, indent, opts)
         # el.attr['anchor'] ||= saner_generate_id(el.value) -- no longer in 1.0.6


### PR DESCRIPTION
@mnot carefully changed the type of code blocks in the QUIC spec to use `~~~drawing`.  Then I found that it was being turned into `<sourcecode>`, which is not really what was intended.  This seems like a fairly safe thing to do, in case others copy QUIC.