### PR TITLE
Add a repo tag to the venue block

### DIFF
--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -58,9 +58,9 @@
         <%=group%> <%=type%> mailing list (<%=mail%>),
         which is archived at <eref target="<%=arch%>"/>.</t>
 <%   end -%>
-<%   if gh = venue[:github] -%>
+<%   if repo = venue[:repo] || (gh = venue[:github]) ? "https://github.com/#{gh}" : nil -%>
       <t>Source for this draft and an issue tracker can be found at
-        <eref target="https://github.com/<%=gh%>"/>.</t>
+        <eref target="<%=repo%>"/>.</t>
 <%   end -%>
     </note>
 <%  venue.warn_if_leftovers -%>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -58,7 +58,7 @@
         <%=group%> <%=type%> mailing list (<%=mail%>),
         which is archived at <eref target="<%=arch%>"/>.</t>
 <%   end -%>
-<%   if repo = venue[:repo] || (gh = venue[:github]) ? "https://github.com/#{gh}" : nil -%>
+<%   if repo = venue[:repo] || ((gh = venue[:github]) && "https://github.com/#{gh}") -%>
       <t>Source for this draft and an issue tracker can be found at
         <eref target="<%=repo%>"/>.</t>
 <%   end -%>


### PR DESCRIPTION
I found the fact that reading `venue[:x]` only works once to be really
non-intuitive, so this is somewhat cumbersome.

I couldn't work out whether this approach to reading the data was
idiomatic.  I'll need to rely on someone with more ruby chops for that.