### PR TITLE
Add a working group home page to the venue info

### DIFF
--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -48,7 +48,7 @@
 <%    venue = KramdownRFC::ParameterSet.new(venue) -%>
     <note title="Discussion Venues" removeInRFC="true">
 <%   mail = venue[:mail] -%>
-<%   homepage = venue[:homepage] -%>
+<%   homepage = venue[:home] -%>
 <%   gtype = venue[:type] -%>
 <%   if mail || homepage -%>
       <t>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -47,17 +47,29 @@
 <%  if venue -%>
 <%    venue = KramdownRFC::ParameterSet.new(venue) -%>
     <note title="Discussion Venues" removeInRFC="true">
-<%   if mail = venue[:mail] -%>
+<%   mail = venue[:mail] -%>
+<%   homepage = venue[:homepage] -%>
+<%   gtype = venue[:type] -%>
+<%   if mail || homepage -%>
+      <t>
+<% end -%>
+<%   if mail -%>
 <%     mail_local, mail_host = mail.split("@", 2) -%>
 <%     mail_subdomain, mail_domain = mail_host.split(".", 2) -%>
 <%     group = venue[:group] || mail_local # XXX -%>
 <%     arch = venue[:arch] || "https://mailarchive.ietf.org/arch/browse/#{mail_local}/" -%>
 <%     GROUPS = {"ietf" => "Working ", "irtf" => "Research "} -%>
-<%     type = venue[:type] || "#{GROUPS[mail_subdomain]}Group" -%>
-      <t>Discussion of this document takes place on the
-        <%=group%> <%=type%> mailing list (<%=mail%>),
-        which is archived at <eref target="<%=arch%>"/>.</t>
+<%     gtype = gtype || "#{GROUPS[mail_subdomain]}Group" -%>
+        Discussion of this document takes place on the
+        <%=group%> <%=gtype%> mailing list (<%=mail%>),
+        which is archived at <eref target="<%=arch%>"/>.
 <%   end -%>
+<%   if homepage -%>
+        <%=gtype%> information can be found at <eref target="<%=homepage%>"/>.
+<%   end -%>
+<%   if mail || homepage -%>
+      </t>
+<% end -%>
 <%   if repo = venue[:repo] || ((gh = venue[:github]) && "https://github.com/#{gh}") -%>
       <t>Source for this draft and an issue tracker can be found at
         <eref target="<%=repo%>"/>.</t>


### PR DESCRIPTION
The HTTP working group needs this.  Based on discussion, I think that
this unblocks them from using this feature.

I've marked this as closing #142, but I think that the upshot of the discussion is that the `repo` tag is sufficient for addressing their special use case, but a working group homepage is what is missing.

Closes #142.