### PR TITLE
Deal with a bad venue/mail

### DIFF
--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -60,8 +60,7 @@
 <%   if mail || homepage -%>
       <t>
 <%   end -%>
-<%   if mail -%>
-<%     mail_local, mail_host = mail.split("@", 2) -%>
+<%   if mail && (mail_local, mail_host = mail.split("@", 2)) && mail_host -%>
 <%     mail_subdomain, mail_domain = mail_host.split(".", 2) -%>
 <%     group = venue[:group] || mail_local # XXX -%>
 <%     arch = venue[:arch] || "https://mailarchive.ietf.org/arch/browse/#{mail_local}/" -%>


### PR DESCRIPTION
If venue/mail is set to something nonsensical (without an '@'), we get a
crash.  That's undesirable, so here we go.  The effect of a bad mail
value is that the mailing list information doesn't appear.