### PR TITLE
Pass through "processing instructions" in v3

### DIFF
--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -18,19 +18,17 @@
                       "number", "obsoletes", "updates", "seriesNo=seriesno")
   pis = KramdownRFC::ParameterSet.new({})
   ps.arr("pi", false) do |pi, val|
-    if $options.v3
-      pis[pi] = {"yes" => "true", "no" => "false", nil => "true", false => "false", "true" => "true"}[val] || val
-    else
--%>
-<?rfc <%=pi%>="<%= {true => "yes", false => "no", nil => "yes"}[val] || escape_html(val.to_s, :attribute) %>"?>
-<%
-    end
+    pis[pi] = {nil => "true", false => "false", "true" => "true"}[val] || val
   end
   if piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
                          "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
     rfcattrs += " " + piattrs
   end
+  pis.rest.each do |pi, val|
+    v = {"true" => "yes", "false" => "no"}[val] || escape_html(val.to_s, :attribute)
 -%>
+<?rfc <%=pi%>="<%=v%>"?>
+<% end -%>
 
 <rfc <%=rfcattrs%>>
   <front>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -22,10 +22,12 @@
   ps.arr("pi", false) do |pi, val|
     pis[pi] = TRUE_FALSE[val] || val
   end
-  piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
-                      "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
-  if piattrs != ""
-    rfcattrs += " " + piattrs
+  if $options.v3
+    piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
+                        "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
+    if piattrs != ""
+      rfcattrs += " " + piattrs
+    end
   end
   pis.rest.each do |pi, val|
     v = YES_NO[val] || escape_html(val.to_s, :attribute)

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -19,7 +19,7 @@
   pis = KramdownRFC::ParameterSet.new({})
   ps.arr("pi", false) do |pi, val|
     if $options.v3
-      pis[pi] = {"yes" => "true", "no" => "false", nil => "true"}[val] || val
+      pis[pi] = {"yes" => "true", "no" => "false", nil => "true", false => "false", "true" => "true"}[val] || val
     else
 -%>
 <?rfc <%=pi%>="<%= {true => "yes", false => "no", nil => "yes"}[val] || escape_html(val.to_s, :attribute) %>"?>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -16,22 +16,21 @@
   rfcattrs = ps.attrs("ipr", "docName=docname", "category=cat",
                       "consensus", "submissionType=submissiontype", "xml:lang=lang",
                       "number", "obsoletes", "updates", "seriesNo=seriesno")
-  if $options.v3
-    ps.arr("pi", false) do |pi, val|
-      keys = ["tocdepth", "toc", "sortrefs", "symrefs"]
-      if keys.index(pi) != nil && !ps.has(pi)
-        ps[pi] = {true => "true", false => "false", nil => "true", "yes" => "true", "no" => "false"}[val] || val
-      end
+  pis = KramdownRFC::ParameterSet.new({})
+  ps.arr("pi", false) do |pi, val|
+    if $options.v3
+      pis[pi] = {"yes" => "true", "no" => "false", nil => "true"}[val] || val
+    else
+-%>
+<?rfc <%=pi%>="<%= {true => "yes", false => "no", nil => "yes"}[val] || escape_html(val.to_s, :attribute) %>"?>
+<%
     end
-    if piattrs = ps.attrs("tocDepth=tocdepth", "tocInclude=toc",
-                          "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
-      rfcattrs += " " + piattrs
-    end
-  else
-    ps.arr("pi", false) do |pi, val| -%>
-<?rfc <%=pi%>="<%= {true => "yes", false => "no", nil => "yes"}[val] || val %>"?>
-<%   end
-  end -%>
+  end
+  if piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
+                         "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
+    rfcattrs += " " + piattrs
+  end
+-%>
 
 <rfc <%=rfcattrs%>>
   <front>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -16,16 +16,19 @@
   rfcattrs = ps.attrs("ipr", "docName=docname", "category=cat",
                       "consensus", "submissionType=submissiontype", "xml:lang=lang",
                       "number", "obsoletes", "updates", "seriesNo=seriesno")
+  TRUE_FALSE = {nil => "true", false => "false", "true" => "true"}
+  YES_NO = {"true" => "yes", "false" => "no"}
   pis = KramdownRFC::ParameterSet.new({})
   ps.arr("pi", false) do |pi, val|
-    pis[pi] = {nil => "true", false => "false", "true" => "true"}[val] || val
+    pis[pi] = TRUE_FALSE[val] || val
   end
-  if piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
-                         "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
+  piattrs = pis.attrs("tocDepth=tocdepth", "tocInclude=toc",
+                      "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
+  if piattrs != ""
     rfcattrs += " " + piattrs
   end
   pis.rest.each do |pi, val|
-    v = {"true" => "yes", "false" => "no"}[val] || escape_html(val.to_s, :attribute)
+    v = YES_NO[val] || escape_html(val.to_s, :attribute)
 -%>
 <?rfc <%=pi%>="<%=v%>"?>
 <% end -%>

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -12,14 +12,28 @@
 <% end -%>
 ]>
 
-<% ps.arr("pi", false) do |pi, val| -%>
+<%
+  rfcattrs = ps.attrs("ipr", "docName=docname", "category=cat",
+                      "consensus", "submissionType=submissiontype", "xml:lang=lang",
+                      "number", "obsoletes", "updates", "seriesNo=seriesno")
+  if $options.v3
+    ps.arr("pi", false) do |pi, val|
+      keys = ["tocdepth", "toc", "sortrefs", "symrefs"]
+      if keys.index(pi) != nil && !ps.has(pi)
+        ps.add(pi, {true => "true", false => "false", nil => "true"}[val] || val)
+      end
+    end
+    if piattrs = ps.attrs("tocDepth=tocdepth", "tocInclude=toc",
+                          "sortRefs=sortrefs", "symRefs=symrefs", "indexInclude=index")
+      rfcattrs += " " + piattrs
+    end
+  else
+    ps.arr("pi", false) do |pi, val| -%>
 <?rfc <%=pi%>="<%= {true => "yes", false => "no", nil => "yes"}[val] || val %>"?>
-<% end -%>
+<%   end
+  end -%>
 
-<rfc <%= ps.attrs("ipr", "docName=docname", "category=cat",
-                  "consensus", "submissionType=submissiontype", "xml:lang=lang",
-                  "number", "obsoletes", "updates", "seriesNo=seriesno") %>>
-
+<rfc <%=rfcattrs%>>
   <front>
     <%= ps.ele("title", ps.attr("abbrev=titleabbrev")) %>
 

--- a/data/kramdown-rfc2629.erb
+++ b/data/kramdown-rfc2629.erb
@@ -20,7 +20,7 @@
     ps.arr("pi", false) do |pi, val|
       keys = ["tocdepth", "toc", "sortrefs", "symrefs"]
       if keys.index(pi) != nil && !ps.has(pi)
-        ps.add(pi, {true => "true", false => "false", nil => "true"}[val] || val)
+        ps[pi] = {true => "true", false => "false", nil => "true", "yes" => "true", "no" => "false"}[val] || val
       end
     end
     if piattrs = ps.attrs("tocDepth=tocdepth", "tocInclude=toc",

--- a/lib/kramdown-rfc/parameterset.rb
+++ b/lib/kramdown-rfc/parameterset.rb
@@ -13,6 +13,9 @@ module KramdownRFC
     def [](pn)
       @f.delete(pn.to_s)
     end
+    def []=(pn, val)
+      @f[pn] = val
+    end
     def has(pn)
       @f[pn.to_s]
     end
@@ -51,9 +54,6 @@ module KramdownRFC
       arr = [arr] if Hash === arr && converthash
       arr << { } if must_have_one && arr.empty?
       Array(arr).each(&block)
-    end
-    def add(pn, val)
-      @f[pn] = val
     end
     def rest
       @f

--- a/lib/kramdown-rfc/parameterset.rb
+++ b/lib/kramdown-rfc/parameterset.rb
@@ -52,6 +52,9 @@ module KramdownRFC
       arr << { } if must_have_one && arr.empty?
       Array(arr).each(&block)
     end
+    def add(pn, val)
+      @f[pn] = val
+    end
     def rest
       @f
     end


### PR DESCRIPTION
There are a small number of attributes on the `<rfc>` element that act
as processing instructions.  These determine if there is a TOC, that
sort of thing.

xml2rfc ignores other PIs when version 3 is enabled, so having these is
a useful way to tune its output.  Passing through attributes directly or
looking at the processing instructions is somewhat useful.

This suppresses processing instructions when producing v3 documents.